### PR TITLE
Prevent returning default route

### DIFF
--- a/routing/routing.go
+++ b/routing/routing.go
@@ -133,6 +133,10 @@ func (r *router) route(routes routeSlice, input net.HardwareAddr, src, dst net.I
 		if rt.InputIface != 0 && rt.InputIface != inputIndex {
 			continue
 		}
+		// default route will have both rt.Src and rt.Dst equal to nil
+		if rt.Src == nil && rt.Dst == nil {
+			continue
+		}
 		if rt.Src != nil && !rt.Src.Contains(src) {
 			continue
 		}


### PR DESCRIPTION
The default route is always matched while having the right network interface for the target IP.  