### PR TITLE
Fix for unhandled error in router.RouteWithSrc

### DIFF
--- a/routing/routing.go
+++ b/routing/routing.go
@@ -100,6 +100,9 @@ func (r *router) RouteWithSrc(input net.HardwareAddr, src, dst net.IP) (iface *n
 		ifaceIndex, gateway, preferredSrc, err = r.route(r.v6, input, src, dst)
 	default:
 		err = errors.New("IP is not valid as IPv4 or IPv6")
+	}
+
+	if err != nil {
 		return
 	}
 


### PR DESCRIPTION
### Fix for unhandled error in router.RouteWithSrc
**Issue:**
panic: runtime error: index out of range at line 109 due to unhandled errors
