### PR TITLE
Fix out of order interface

### DIFF
--- a/routing/routing.go
+++ b/routing/routing.go
@@ -219,9 +219,6 @@ loop:
 		return nil, err
 	}
 	for i, iface := range ifaces {
-		if i != iface.Index-1 {
-			return nil, fmt.Errorf("out of order iface %d = %v", i, iface)
-		}
 		rtr.ifaces = append(rtr.ifaces, iface)
 		var addrs ipAddrs
 		ifaceAddrs, err := iface.Addrs()

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -218,7 +218,7 @@ loop:
 	if err != nil {
 		return nil, err
 	}
-	for i, iface := range ifaces {
+	for _, iface := range ifaces {
 		rtr.ifaces = append(rtr.ifaces, iface)
 		var addrs ipAddrs
 		ifaceAddrs, err := iface.Addrs()


### PR DESCRIPTION
The interfaces are returned with out of order index when they are hot swapped(e.g., USB Ethernet Adapter). I don't understand why the condition needs to be checked in the first place as we don't use the index anywhere.

Reported the issue here #830 but not response. So, removing it to make it work in hot swapped network interfaces.